### PR TITLE
PlayerCollector accesses InfluxDB connector before initialized + Fix InfluxDB database creation

### DIFF
--- a/minefana-bukkit/src/main/java/com/github/games647/minefana/MinefanaBukkit.java
+++ b/minefana-bukkit/src/main/java/com/github/games647/minefana/MinefanaBukkit.java
@@ -20,7 +20,7 @@ public class MinefanaBukkit extends JavaPlugin implements AnalyticsPlugin {
 
     private final Logger logger = LoggerFactory.getLogger(getName());
     private final AnalyticsCore core = new AnalyticsCore(this, logger);
-    private final BukkitPlayerCollector playerCollector= new BukkitPlayerCollector(core);
+    private BukkitPlayerCollector playerCollector;
 
     @Override
     public void onEnable() {
@@ -58,6 +58,8 @@ public class MinefanaBukkit extends JavaPlugin implements AnalyticsPlugin {
         scheduler.runTaskTimer(this, pingTask, 40L, 40L);
 
         scheduler.runTaskTimer(this, new BukkitWorldCollector(core.getConnector()), 5 * 60 * 20L, 5 * 60 * 20L);
+
+        playerCollector = new BukkitPlayerCollector(core);
         scheduler.runTaskTimer(this, playerCollector, 15 * 60 * 20L, 15 * 60 * 20L);
     }
 

--- a/minefana-bungeecord/src/main/java/com/github/games647/minefana/MinefanaBungee.java
+++ b/minefana-bungeecord/src/main/java/com/github/games647/minefana/MinefanaBungee.java
@@ -20,7 +20,7 @@ public class MinefanaBungee extends Plugin implements AnalyticsPlugin {
 
     private final Logger logger = LoggerFactory.getLogger(getDescription().getName());
     private final AnalyticsCore core = new AnalyticsCore(this, logger);
-    private final BungeePlayerCollector playerCollector = new BungeePlayerCollector(core);
+    private BungeePlayerCollector playerCollector;
 
     @Override
     public void onEnable() {
@@ -47,6 +47,8 @@ public class MinefanaBungee extends Plugin implements AnalyticsPlugin {
                 .mapToInt(ProxiedPlayer::getPing)
                 .average().orElse(0));
         scheduler.schedule(this, pingTask, 2, 2, TimeUnit.SECONDS);
+
+        playerCollector = new BungeePlayerCollector(core);
 
         scheduler.schedule(this, playerCollector, 15, 15, TimeUnit.MINUTES);
     }

--- a/minefana-common/src/main/java/com/github/games647/minefana/common/InfluxConnector.java
+++ b/minefana-common/src/main/java/com/github/games647/minefana/common/InfluxConnector.java
@@ -28,7 +28,7 @@ public class InfluxConnector implements Closeable {
     protected void init() {
         InfluxDB influxDB = InfluxDBFactory.connect(url, username, password);
 
-        if (influxDB.databaseExists(database)) {
+        if (!influxDB.databaseExists(database)) {
             influxDB.createDatabase(database);
         }
 

--- a/minefana-common/src/main/java/com/github/games647/minefana/common/InfluxConnector.java
+++ b/minefana-common/src/main/java/com/github/games647/minefana/common/InfluxConnector.java
@@ -27,7 +27,10 @@ public class InfluxConnector implements Closeable {
 
     protected void init() {
         InfluxDB influxDB = InfluxDBFactory.connect(url, username, password);
-        influxDB.createDatabase(username);
+
+        if (influxDB.databaseExists(database)) {
+            influxDB.createDatabase(database);
+        }
 
         // Flush every 2000 Points, at least every 1s
         influxDB.enableBatch(2_000, 1_000, TimeUnit.MILLISECONDS);

--- a/minefana-sponge/src/main/java/com/github/games647/minefana/MinefanaSponge.java
+++ b/minefana-sponge/src/main/java/com/github/games647/minefana/MinefanaSponge.java
@@ -33,7 +33,7 @@ public class MinefanaSponge implements AnalyticsPlugin {
     private final Logger logger;
     private final AnalyticsCore core;
     private final Injector injector;
-    private final SpongePlayerCollector playerCollector;
+    private SpongePlayerCollector playerCollector;
 
     @Inject
     @DefaultConfig(sharedRoot = false)
@@ -44,7 +44,6 @@ public class MinefanaSponge implements AnalyticsPlugin {
         this.logger = logger;
 
         this.core = new AnalyticsCore(this, logger);
-        this.playerCollector = new SpongePlayerCollector(core);
         this.injector = injector.createChildInjector(binder -> {
             binder.bind(AnalyticsCore.class).toInstance(core);
             binder.bind(InfluxConnector.class).toInstance(core.getConnector());
@@ -54,6 +53,8 @@ public class MinefanaSponge implements AnalyticsPlugin {
     @Listener
     public void onServerInit(GameInitializationEvent initEvent) {
         core.initialize();
+
+        this.playerCollector = new SpongePlayerCollector(core);
     }
 
     @Listener


### PR DESCRIPTION
The PlayerCollector class should not be instanced before the InfluxDB connector is instanced.

In case of Bukkit, the initialization is triggered once Bukkit calls the `onEnable` method. But at this time, the PlayerCollector is already instanced with `null` as InfluxDB connector causing the `run` method of the PlayerCollector throwing a NullPointerException.

My second change fixes the InfluxDB database name. Previously you used the username instead of the database. And you also only should create the database if it does not exist yet.