### PR TITLE
Use single metric for world data and use "world" tag instead of fields

### DIFF
--- a/minefana-common/src/main/java/com/github/games647/minefana/common/AnalyticsType.java
+++ b/minefana-common/src/main/java/com/github/games647/minefana/common/AnalyticsType.java
@@ -11,10 +11,7 @@ public enum AnalyticsType {
     USERS,
     BUNGEE_PLAYER_PER_SERVER,
 
-    WORLD_PLAYERS,
-    WORLD_CHUNKS,
-    WORLD_ENTITIES,
-    WORLD_TILE_ENTITIES,
+    WORLD,
 
     FORGE_USER,
     FORGE_MODS,

--- a/minefana-common/src/main/java/com/github/games647/minefana/common/collectors/WorldCollector.java
+++ b/minefana-common/src/main/java/com/github/games647/minefana/common/collectors/WorldCollector.java
@@ -24,7 +24,7 @@ public abstract class WorldCollector<W> extends AbstractCollector {
                     .addField("players", getPlayers(world))
                     .addField("chunks", getChunks(world))
                     .addField("entities", getEntities(world))
-                    .addField("tilesEntities", getTileEntities(world));
+                    .addField("tileEntities", getTileEntities(world));
 
             send(pointBuilder);
         }

--- a/minefana-common/src/main/java/com/github/games647/minefana/common/collectors/WorldCollector.java
+++ b/minefana-common/src/main/java/com/github/games647/minefana/common/collectors/WorldCollector.java
@@ -15,23 +15,19 @@ public abstract class WorldCollector<W> extends AbstractCollector {
 
     @Override
     public void run() {
-        Point.Builder playersBuilder = AnalyticsType.WORLD_PLAYERS.newPoint();
-        Point.Builder chunksBuilder = AnalyticsType.WORLD_CHUNKS.newPoint();
-        Point.Builder entityBuilder = AnalyticsType.WORLD_ENTITIES.newPoint();
-        Point.Builder tileBuilder = AnalyticsType.WORLD_TILE_ENTITIES.newPoint();
         for (W world : getWorlds()) {
             String worldName = getName(world);
 
-            playersBuilder.addField(worldName, getPlayers(world));
-            chunksBuilder.addField(worldName, getChunks(world));
-            entityBuilder.addField(worldName, getEntities(world));
-            tileBuilder.addField(worldName, getTileEntities(world));
-        }
+            Point.Builder pointBuilder = AnalyticsType.WORLD.newPoint();
 
-        send(playersBuilder);
-        send(chunksBuilder);
-        send(entityBuilder);
-        send(tileBuilder);
+            pointBuilder.tag("world", worldName)
+                    .addField("players", getPlayers(world))
+                    .addField("chunks", getChunks(world))
+                    .addField("entities", getEntities(world))
+                    .addField("tilesEntities", getTileEntities(world));
+
+            send(pointBuilder);
+        }
     }
 
     protected abstract Collection<W> getWorlds();


### PR DESCRIPTION
Using a field for each world makes it really hard to automatically let Grafana create the graphs (especially if you use plugins like Multiverse and have a dynamically changing number of worlds). Therefore I use a tag "world" which I can use in Grafana to group by the tag.

Additionally I changed the WORLD_* metrics to a single metric "WORLD" which now uses the fields chunks, entities, tileEntities and players. I'm not sure whether that is the right/better way, but for me it looks like the right one.